### PR TITLE
Add lightweight PHPUnit harness and tests for core workflows

### DIFF
--- a/class/Common/Configurator.php
+++ b/class/Common/Configurator.php
@@ -56,8 +56,8 @@ class Configurator
         $this->templateFolders = $config->templateFolders;
         $this->oldFiles        = $config->oldFiles;
         $this->oldFolders      = $config->oldFolders;
-        $this->renameTables    = $config->renameTables;
-        $this->renameColumns   = $config->renameColumns;
+        $this->renameTables    = $config->renameTables ?? [];
+        $this->renameColumns   = $config->renameColumns ?? [];
         $this->moduleStats     = $config->moduleStats;
         $this->modCopyright    = $config->modCopyright;
 

--- a/class/Helper.php
+++ b/class/Helper.php
@@ -28,6 +28,9 @@ class Helper extends \Xmf\Module\Helper
 {
     public $debug;
 
+    /** @var self|null */
+    protected static $helperInstance;
+
     /**
      * @param bool $debug
      */
@@ -47,12 +50,25 @@ class Helper extends \Xmf\Module\Helper
      */
     public static function getInstance($debug = false)
     {
-        static $instance;
-        if (null === $instance) {
-            $instance = new static($debug);
+        if (null === static::$helperInstance) {
+            static::$helperInstance = new static($debug);
         }
 
-        return $instance;
+        return static::$helperInstance;
+    }
+
+    /**
+     * Replace the stored helper instance
+     *
+     * Primarily intended for unit tests where we want to inject
+     * bespoke handler implementations without touching the
+     * singleton bootstrap logic used in production.
+     *
+     * @param self|null $helper
+     */
+    public static function setInstance(?self $helper = null): void
+    {
+        static::$helperInstance = $helper;
     }
 
     /**

--- a/class/Tree.php
+++ b/class/Tree.php
@@ -61,16 +61,16 @@ class Tree extends \XoopsObject
         $parents = ['mother' => ['id' => 0, 'name' => ''], 'father' => ['id' => 0, 'name' => '']]; //init the
         //get the Tree Handler and retrieve parent info
         $treeHandler = XoopsModules\Pedigree\Helper::getInstance()->getHandler('Tree');
-        if (!$this->getVar('mother')) {
+        if ($this->getVar('mother') > 0) {
             $motherObj = $treeHandler->get($this->getVar('mother'));
             if ($motherObj instanceof XoopsModules\Pedigree\Tree && !$motherObj->isNew()) {
-                $parents['mother'] = ['id' => $motherObj->geVar('id'), 'name' => $motherObj->getVar('pname')];
+                $parents['mother'] = ['id' => $motherObj->getVar('id'), 'name' => $motherObj->getVar('pname')];
             }
         }
-        if (!$this->getVar('father')) {
+        if ($this->getVar('father') > 0) {
             $fatherObj = $treeHandler->get($this->getVar('father'));
             if ($fatherObj instanceof XoopsModules\Pedigree\Tree && !$fatherObj->isNew()) {
-                $parents['father'] = ['id' => $fatherObj->geVar('id'), 'name' => $fatherObj->getVar('pname')];
+                $parents['father'] = ['id' => $fatherObj->getVar('id'), 'name' => $fatherObj->getVar('pname')];
             }
         }
         return $parents;

--- a/tests/Unit/ConfiguratorTest.php
+++ b/tests/Unit/ConfiguratorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use XoopsModules\Pedigree\Common\Configurator;
+
+final class ConfiguratorTest extends TestCase
+{
+    public function testConfiguratorBootstrapsModulePathsAndIcons(): void
+    {
+        $configurator = new Configurator();
+
+        self::assertSame('PEDIGREE ModuleConfigurator', $configurator->name);
+        self::assertNotNull($configurator->paths, 'Paths configuration should be initialised.');
+        self::assertNotNull($configurator->icons, 'Icon configuration should be initialised.');
+
+        $uploadFolders = $configurator->uploadFolders;
+        self::assertTrue(in_array(XOOPS_UPLOAD_PATH . '/pedigree/pedigree_config', $uploadFolders, true));
+
+        $paths = (array)$configurator->paths->paths;
+        self::assertSame(XOOPS_ROOT_PATH . '/modules/pedigree', $paths['modPath']);
+        self::assertSame(XOOPS_URL . '/modules/pedigree', $paths['modUrl']);
+
+        $icons = (array)$configurator->icons;
+        self::assertArrayHasKey('edit', $icons);
+        self::assertArrayHasKey('delete', $icons);
+        self::assertArrayHasKey('add', $icons);
+    }
+}

--- a/tests/Unit/FieldsTest.php
+++ b/tests/Unit/FieldsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use XoopsModules\Pedigree\Fields;
+
+final class FieldsTest extends TestCase
+{
+    public function testBooleanAccessorsReflectPersistedConfiguration(): void
+    {
+        $field = new Fields();
+        $field->setVar('id', 7);
+        $field->setVar('fieldname', 'colour');
+        $field->setVar('isactive', 1);
+        $field->setVar('viewinadvanced', 0);
+        $field->setVar('hassearch', 1);
+        $field->setVar('litter', 1);
+        $field->setVar('generallitter', 0);
+        $field->setVar('lookuptable', 1);
+        $field->setVar('viewinlist', 1);
+        $field->setVar('viewinpedigree', 1);
+        $field->setVar('viewinpie', 0);
+
+        self::assertSame('colour', (string)$field, 'Casting should return the configured field name.');
+        self::assertSame(7, $field->getId());
+        self::assertTrue($field->isActive());
+        self::assertFalse($field->inAdvanced());
+        self::assertTrue($field->hasSearch());
+        self::assertTrue($field->addLitter());
+        self::assertFalse($field->generalLitter());
+        self::assertTrue($field->hasLookup());
+        self::assertTrue($field->inList());
+        self::assertTrue($field->inPedigree());
+        self::assertFalse($field->inPie());
+    }
+
+    public function testIdentifierFallsBackToZeroWhenUnset(): void
+    {
+        $field = new Fields();
+        self::assertSame(0, $field->getId());
+
+        $field->setVar('id', 13);
+        self::assertSame(13, $field->getId());
+    }
+}

--- a/tests/Unit/TreeTest.php
+++ b/tests/Unit/TreeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use XoopsModules\Pedigree\Helper;
+use XoopsModules\Pedigree\Tree;
+
+final class TreeTest extends TestCase
+{
+    /** @var StubTreeRepository */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = new StubTreeRepository();
+        $helper = new class extends Helper {
+            /** @var array<string,mixed> */
+            private $handlers = [];
+
+            public function setHandler(string $name, $handler): void
+            {
+                $this->handlers[strtolower($name)] = $handler;
+            }
+
+            public function getHandler($name)
+            {
+                $key = strtolower($name);
+                if (isset($this->handlers[$key])) {
+                    return $this->handlers[$key];
+                }
+
+                return parent::getHandler($name);
+            }
+        };
+        $helper->setHandler('Tree', $this->repository);
+        Helper::setInstance($helper);
+    }
+
+    protected function tearDown(): void
+    {
+        Helper::setInstance(null);
+    }
+
+    public function testGetParentsReturnsPopulatedParentInformation(): void
+    {
+        $mother = $this->repository->persistFromData(['id' => 101, 'pname' => 'Matriarch']);
+        $father = $this->repository->persistFromData(['id' => 202, 'pname' => 'Patriarch']);
+
+        $subject = new Tree();
+        $subject->setVar('mother', $mother->getVar('id'));
+        $subject->setVar('father', $father->getVar('id'));
+
+        $parents = $subject->getParents();
+
+        self::assertSame(['id' => 101, 'name' => 'Matriarch'], $parents['mother']);
+        self::assertSame(['id' => 202, 'name' => 'Patriarch'], $parents['father']);
+    }
+
+    public function testGetParentsReturnsDefaultWhenParentMissing(): void
+    {
+        $subject = new Tree();
+        $subject->setVar('mother', 0);
+        $subject->setVar('father', 0);
+
+        $parents = $subject->getParents();
+
+        self::assertSame(['id' => 0, 'name' => ''], $parents['mother']);
+        self::assertSame(['id' => 0, 'name' => ''], $parents['father']);
+    }
+}
+
+final class StubTreeRepository
+{
+    /** @var array<int,Tree> */
+    private $records = [];
+
+    public function persistFromData(array $data): Tree
+    {
+        $tree = new Tree();
+        $tree->assignVars($data);
+        $tree->unsetNew();
+        $this->records[(int)$tree->getVar('id')] = $tree;
+
+        return $tree;
+    }
+
+    public function get(int $id): ?Tree
+    {
+        return $this->records[$id] ?? null;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+
+// Define XOOPS constants expected by the module configuration files
+if (!\defined('XOOPS_ROOT_PATH')) {
+    \define('XOOPS_ROOT_PATH', \dirname(__DIR__));
+}
+if (!\defined('XOOPS_URL')) {
+    \define('XOOPS_URL', 'https://xoops.invalid');
+}
+if (!\defined('XOOPS_UPLOAD_PATH')) {
+    \define('XOOPS_UPLOAD_PATH', XOOPS_ROOT_PATH . '/uploads');
+}
+if (!\defined('XOOPS_UPLOAD_URL')) {
+    \define('XOOPS_UPLOAD_URL', XOOPS_URL . '/uploads');
+}
+if (!\defined('_EDIT')) {
+    \define('_EDIT', 'Edit');
+}
+if (!\defined('_DELETE')) {
+    \define('_DELETE', 'Delete');
+}
+if (!\defined('_CLONE')) {
+    \define('_CLONE', 'Clone');
+}
+if (!\defined('_PREVIEW')) {
+    \define('_PREVIEW', 'Preview');
+}
+if (!\defined('_PRINT')) {
+    \define('_PRINT', 'Print');
+}
+if (!\defined('_PDF')) {
+    \define('_PDF', 'Pdf');
+}
+if (!\defined('_ADD')) {
+    \define('_ADD', 'Add');
+}
+if (!\defined('_OFF')) {
+    \define('_OFF', 'Off');
+}
+if (!\defined('_ON')) {
+    \define('_ON', 'On');
+}
+if (!\defined('XOBJ_DTYPE_INT')) {
+    \define('XOBJ_DTYPE_INT', 1);
+}
+if (!\defined('XOBJ_DTYPE_TXTAREA')) {
+    \define('XOBJ_DTYPE_TXTAREA', 2);
+}
+if (!\defined('XOBJ_DTYPE_TXTBOX')) {
+    \define('XOBJ_DTYPE_TXTBOX', 3);
+}
+if (!\defined('XOBJ_DTYPE_ENUM')) {
+    \define('XOBJ_DTYPE_ENUM', 4);
+}
+
+// Provide a minimal $xoops helper with the path() method expected by the module
+if (!isset($GLOBALS['xoops'])) {
+    $GLOBALS['xoops'] = new class {
+        public function path(string $path): string
+        {
+            return XOOPS_ROOT_PATH . '/' . \ltrim($path, '/');
+        }
+    };
+}
+
+// Lightweight stubs that mimic the pieces of XOOPS used by the tests
+if (!\class_exists('XoopsObject')) {
+    abstract class XoopsObject
+    {
+        /** @var array<string,mixed> */
+        protected $vars = [];
+        /** @var bool */
+        protected $isNew = true;
+
+        public function __construct()
+        {
+        }
+
+        public function initVar($key, $type, $default = null, $required = false, $maxlength = null): void
+        {
+            $this->vars[$key] = $default;
+        }
+
+        public function setVar(string $key, $value): void
+        {
+            $this->vars[$key] = $value;
+        }
+
+        public function assignVars(array $values): void
+        {
+            foreach ($values as $key => $value) {
+                $this->setVar($key, $value);
+            }
+            $this->unsetNew();
+        }
+
+        public function getVar(string $key)
+        {
+            return $this->vars[$key] ?? null;
+        }
+
+        public function setNew(): void
+        {
+            $this->isNew = true;
+        }
+
+        public function unsetNew(): void
+        {
+            $this->isNew = false;
+        }
+
+        public function isNew(): bool
+        {
+            return $this->isNew;
+        }
+    }
+}
+
+if (!\class_exists('XoopsPersistableObjectHandler')) {
+    abstract class XoopsPersistableObjectHandler
+    {
+        /** @var array<int|string,XoopsObject> */
+        protected $objects = [];
+        /** @var string */
+        protected $className;
+        /** @var string */
+        protected $keyName;
+
+        public function __construct($db = null, string $table = '', string $className = '', string $keyName = '', string $identifierName = '')
+        {
+            $this->className = $className;
+            $this->keyName   = $keyName;
+        }
+
+        public function create(bool $isNew = true): XoopsObject
+        {
+            $class = $this->className;
+            /** @var XoopsObject $object */
+            $object = new $class();
+            if ($isNew) {
+                $object->setNew();
+            } else {
+                $object->unsetNew();
+            }
+
+            return $object;
+        }
+
+        public function insert(XoopsObject $object)
+        {
+            $key = $object->getVar($this->keyName);
+            $this->objects[$key] = $object;
+
+            return $key;
+        }
+
+        public function get($id)
+        {
+            return $this->objects[$id] ?? null;
+        }
+    }
+}
+
+if (!\class_exists('XoopsDatabaseFactory')) {
+    class XoopsDatabaseFactory
+    {
+        public static function getDatabaseConnection()
+        {
+            return new XoopsMySQLDatabase();
+        }
+    }
+}
+
+if (!\class_exists('XoopsDatabase')) {
+    class XoopsDatabase
+    {
+    }
+}
+
+if (!\class_exists('XoopsMySQLDatabase')) {
+    class XoopsMySQLDatabase extends XoopsDatabase
+    {
+    }
+}
+
+if (!\class_exists('Criteria')) {
+    class Criteria
+    {
+        public function __construct($column = null, $value = null, $operator = '=', $prefix = '', $function = '')
+        {
+        }
+    }
+}
+
+if (!\class_exists('CriteriaCompo')) {
+    class CriteriaCompo extends Criteria
+    {
+        public function add($criteria, $condition = 'AND')
+        {
+            return $this;
+        }
+
+        public function setSort($sort)
+        {
+            return $this;
+        }
+
+        public function setOrder($order)
+        {
+            return $this;
+        }
+
+        public function setLimit($limit)
+        {
+            return $this;
+        }
+    }
+}
+
+if (!\class_exists('Xmf\\Module\\Helper')) {
+    \class_alias('PedigreeTest\\XmfModuleHelperStub', 'Xmf\\Module\\Helper');
+}
+
+}
+
+namespace PedigreeTest {
+    class XmfModuleHelperStub
+    {
+        protected $dirname;
+
+        public function __construct(string $dirname)
+        {
+            $this->dirname = $dirname;
+        }
+
+        public function addLog(string $message): void
+        {
+        }
+    }
+}
+
+namespace {
+    if (!\class_exists('Xmf\\Module\\Admin')) {
+        class_alias('PedigreeTest\\XmfModuleAdminStub', 'Xmf\\Module\\Admin');
+    }
+}
+
+namespace PedigreeTest {
+    class XmfModuleAdminStub
+    {
+        public static function iconUrl(string $path = '', int $size = 16): string
+        {
+            $path = \trim($path, '/');
+            if ('' === $path) {
+                return 'icons';
+            }
+
+            return 'icons/' . $path;
+        }
+    }
+}
+
+namespace {
+    if (!\class_exists('PHPUnit\\Framework\\TestCase')) {
+        require __DIR__ . '/support/TestCase.php';
+    }
+
+    spl_autoload_register(static function (string $class): void {
+        $prefix = 'XoopsModules\\Pedigree\\';
+        if (0 === strpos($class, $prefix)) {
+            $relative = substr($class, \strlen($prefix));
+            $relativePath = str_replace('\\', '/', $relative);
+            $paths = [
+                __DIR__ . '/../class/' . $relativePath . '.php',
+                __DIR__ . '/../preloads/' . $relativePath . '.php',
+            ];
+            foreach ($paths as $file) {
+                if (is_file($file)) {
+                    require_once $file;
+                    return;
+                }
+            }
+        }
+    });
+}

--- a/tests/support/TestCase.php
+++ b/tests/support/TestCase.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPUnit\Framework;
+
+use Throwable;
+
+class AssertionFailedError extends \Exception
+{
+}
+
+abstract class TestCase
+{
+    /** @var list<array{test:string,status:string,message?:string,exception?:Throwable}> */
+    private $results = [];
+
+    /**
+     * Override in child classes to provide per-test setup
+     */
+    protected function setUp(): void
+    {
+    }
+
+    /**
+     * Override in child classes to provide per-test teardown
+     */
+    protected function tearDown(): void
+    {
+    }
+
+    /**
+     * Execute all test* methods in the current test case.
+     *
+     * @return array{class:string,count:int,passed:int,failures:list<mixed>,errors:list<mixed>,details:list<mixed>}
+     */
+    public function run(): array
+    {
+        $methods = array_filter(get_class_methods($this), static function (string $method): bool {
+            return 0 === strpos($method, 'test');
+        });
+        sort($methods);
+
+        $failures = [];
+        $errors   = [];
+        $details  = [];
+
+        foreach ($methods as $method) {
+            $status   = 'passed';
+            $message  = '';
+            $exception = null;
+
+            try {
+                $this->setUp();
+                $this->$method();
+            } catch (AssertionFailedError $failure) {
+                $status   = 'failure';
+                $message  = $failure->getMessage();
+                $exception = $failure;
+            } catch (Throwable $throwable) {
+                $status   = 'error';
+                $message  = $throwable->getMessage();
+                $exception = $throwable;
+            }
+
+            try {
+                $this->tearDown();
+            } catch (Throwable $teardown) {
+                $status   = 'error';
+                $message  = 'tearDown failure: ' . $teardown->getMessage();
+                $exception = $teardown;
+            }
+
+            if ('failure' === $status) {
+                $failures[] = ['test' => $method, 'message' => $message, 'exception' => $exception];
+            } elseif ('error' === $status) {
+                $errors[] = ['test' => $method, 'message' => $message, 'exception' => $exception];
+            }
+
+            $details[] = ['test' => $method, 'status' => $status, 'message' => $message];
+        }
+
+        $count  = count($methods);
+        $passed = $count - count($failures) - count($errors);
+
+        return [
+            'class'    => static::class,
+            'count'    => $count,
+            'passed'   => $passed,
+            'failures' => $failures,
+            'errors'   => $errors,
+            'details'  => $details,
+        ];
+    }
+
+    protected static function failureDescription($expected, $actual): string
+    {
+        return 'Failed asserting that ' . var_export($actual, true) . ' matches expected ' . var_export($expected, true);
+    }
+
+    public static function assertTrue($condition, string $message = ''): void
+    {
+        if (true !== $condition) {
+            throw new AssertionFailedError($message ?: 'Failed asserting that condition is true.');
+        }
+    }
+
+    public static function assertFalse($condition, string $message = ''): void
+    {
+        if (false !== $condition) {
+            throw new AssertionFailedError($message ?: 'Failed asserting that condition is false.');
+        }
+    }
+
+    public static function assertSame($expected, $actual, string $message = ''): void
+    {
+        if ($expected !== $actual) {
+            throw new AssertionFailedError($message ?: self::failureDescription($expected, $actual));
+        }
+    }
+
+    public static function assertEquals($expected, $actual, string $message = ''): void
+    {
+        if ($expected != $actual) {
+            throw new AssertionFailedError($message ?: self::failureDescription($expected, $actual));
+        }
+    }
+
+    public static function assertInstanceOf(string $expected, $actual, string $message = ''): void
+    {
+        if (!($actual instanceof $expected)) {
+            throw new AssertionFailedError($message ?: 'Failed asserting that object is instance of ' . $expected . '.');
+        }
+    }
+
+    public static function assertNull($actual, string $message = ''): void
+    {
+        if (null !== $actual) {
+            throw new AssertionFailedError($message ?: 'Failed asserting that value is null.');
+        }
+    }
+
+    public static function assertNotNull($actual, string $message = ''): void
+    {
+        if (null === $actual) {
+            throw new AssertionFailedError($message ?: 'Failed asserting that value is not null.');
+        }
+    }
+
+    public static function assertArrayHasKey($key, array $array, string $message = ''): void
+    {
+        if (!array_key_exists($key, $array)) {
+            throw new AssertionFailedError($message ?: sprintf('Failed asserting that the array has the key %s.', var_export($key, true)));
+        }
+    }
+
+    public static function fail(string $message = ''): void
+    {
+        throw new AssertionFailedError($message ?: 'Failed assertion.');
+    }
+}

--- a/vendor/bin/phpunit
+++ b/vendor/bin/phpunit
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = \dirname(__DIR__, 2);
+require $root . '/tests/bootstrap.php';
+
+$testDir = $root . '/tests';
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($testDir, RecursiveDirectoryIterator::SKIP_DOTS)
+);
+
+$testFiles = [];
+foreach ($iterator as $file) {
+    if ('php' !== strtolower($file->getExtension())) {
+        continue;
+    }
+    if (!preg_match('/Test\\.php$/', $file->getFilename())) {
+        continue;
+    }
+    $testFiles[] = $file->getPathname();
+}
+
+sort($testFiles);
+
+foreach ($testFiles as $file) {
+    require_once $file;
+}
+
+$declared = get_declared_classes();
+$testClasses = array_filter($declared, static function (string $class): bool {
+    return is_subclass_of($class, PHPUnit\Framework\TestCase::class);
+});
+
+sort($testClasses);
+
+$totalTests   = 0;
+$totalPassed  = 0;
+$totalFailures = 0;
+$totalErrors   = 0;
+$failureOutput = [];
+$outputLine    = '';
+
+foreach ($testClasses as $class) {
+    /** @var PHPUnit\Framework\TestCase $instance */
+    $instance = new $class();
+    $result   = $instance->run();
+
+    foreach ($result['details'] as $detail) {
+        if ('passed' === $detail['status']) {
+            $outputLine .= '.';
+        } elseif ('failure' === $detail['status']) {
+            $outputLine .= 'F';
+            $failureOutput[] = sprintf("%s::%s\n%s\n", $result['class'], $detail['test'], $detail['message']);
+        } else {
+            $outputLine .= 'E';
+            $failureOutput[] = sprintf("%s::%s\n%s\n", $result['class'], $detail['test'], $detail['message']);
+        }
+    }
+
+    $totalTests   += $result['count'];
+    $totalPassed  += $result['passed'];
+    $totalFailures += count($result['failures']);
+    $totalErrors   += count($result['errors']);
+}
+
+if ('' !== $outputLine) {
+    echo $outputLine, "\n\n";
+}
+
+if ($failureOutput) {
+    foreach ($failureOutput as $failure) {
+        echo $failure, "\n";
+    }
+}
+
+echo sprintf(
+    "Tests: %d, Passed: %d, Failures: %d, Errors: %d\n",
+    $totalTests,
+    $totalPassed,
+    $totalFailures,
+    $totalErrors
+);
+
+exit(($totalFailures + $totalErrors) > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- allow injecting a custom Pedigree helper instance to make handler stubbing feasible in tests
- harden the configurator defaults and pedigree tree parent lookup logic
- add a lightweight PHPUnit-style harness with unit tests that cover field flags, parent resolution, and admin configurator wiring

## Testing
- php vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d221bcce448323bf2e1f8eef8d4517